### PR TITLE
Return index and end position

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Aho-Corasick string matching algorithm for golang
 
-
 ~~~ go
 package main
 
@@ -20,12 +19,9 @@ func main() {
 
 	ret := ac.Match("hello世界, hello google, i love golang!!!")
 
-	for _, i := range ret {
-		fmt.Println(dictionary[i])
+	for _, term := range ret {
+		fmt.Printf("%d %s\n", term.EndPosition-len(dictionary[term.Index])+1, dictionary[term.Index])
 	}
-}
-
-
 ~~~
 
 ## LICENSE

--- a/ahocorasick.go
+++ b/ahocorasick.go
@@ -23,7 +23,6 @@ func newTrieNode() *trieNode {
 type Matcher struct {
 	root *trieNode
 	size int
-	mark []bool
 }
 
 type Term struct {
@@ -35,7 +34,6 @@ func NewMatcher() *Matcher {
 	return &Matcher{
 		root: newTrieNode(),
 		size: 0,
-		mark: make([]bool, 0),
 	}
 }
 
@@ -43,7 +41,6 @@ func BuildNewMatcher(dictionary []string) *Matcher {
 	m := &Matcher{
 		root: newTrieNode(),
 		size: 0,
-		mark: make([]bool, 0),
 	}
 	m.Build(dictionary)
 	return m
@@ -55,16 +52,15 @@ func (m *Matcher) Build(dictionary []string) {
 		m.insert(dictionary[i])
 	}
 	m.build()
-	m.mark = make([]bool, m.size)
 }
 
 // string match search
 // return all strings matched as indexes into the original dictionary and their positions on matched string
 func (m *Matcher) Match(s string) []*Term {
 	curNode := m.root
-	m.resetMark()
 	var p *trieNode = nil
 
+	mark := make([]bool, m.size)
 	ret := make([]*Term, 0)
 
 	for index, rune := range s {
@@ -77,8 +73,8 @@ func (m *Matcher) Match(s string) []*Term {
 		}
 
 		p = curNode
-		for p != m.root && p.count > 0 && !m.mark[p.index] {
-			m.mark[p.index] = true
+		for p != m.root && p.count > 0 && !mark[p.index] {
+			mark[p.index] = true
 			for i := 0; i < p.count; i++ {
 				ret = append(ret, &Term{Index: p.index, EndPosition: index})
 			}
@@ -91,11 +87,10 @@ func (m *Matcher) Match(s string) []*Term {
 
 // just return the number of len(Match(s))
 func (m *Matcher) GetMatchResultSize(s string) int {
-
 	curNode := m.root
-	m.resetMark()
 	var p *trieNode = nil
 
+	mark := make([]bool, m.size)
 	num := 0
 
 	for _, v := range s {
@@ -108,8 +103,8 @@ func (m *Matcher) GetMatchResultSize(s string) int {
 		}
 
 		p = curNode
-		for p != m.root && p.count > 0 && !m.mark[p.index] {
-			m.mark[p.index] = true
+		for p != m.root && p.count > 0 && !mark[p.index] {
+			mark[p.index] = true
 			num += p.count
 			p = p.fail
 		}
@@ -157,10 +152,4 @@ func (m *Matcher) insert(s string) {
 	curNode.count++
 	curNode.index = m.size
 	m.size++
-}
-
-func (m *Matcher) resetMark() {
-	for i := 0; i < m.size; i++ {
-		m.mark[i] = false
-	}
 }

--- a/ahocorasick.go
+++ b/ahocorasick.go
@@ -26,6 +26,11 @@ type Matcher struct {
 	mark []bool
 }
 
+type Term struct {
+	Index       int
+	EndPosition int
+}
+
 func NewMatcher() *Matcher {
 	return &Matcher{
 		root: newTrieNode(),
@@ -45,37 +50,37 @@ func BuildNewMatcher(dictionary []string) *Matcher {
 }
 
 // initialize the ahocorasick
-func (this *Matcher) Build(dictionary []string) {
-	for i, _ := range dictionary {
-		this.insert(dictionary[i])
+func (m *Matcher) Build(dictionary []string) {
+	for i := range dictionary {
+		m.insert(dictionary[i])
 	}
-	this.build()
-	this.mark = make([]bool, this.size)
+	m.build()
+	m.mark = make([]bool, m.size)
 }
 
 // string match search
-// return all strings matched as indexes into the original dictionary
-func (this *Matcher) Match(s string) []int {
-	curNode := this.root
-	this.resetMark()
+// return all strings matched as indexes into the original dictionary and their positions on matched string
+func (m *Matcher) Match(s string) []*Term {
+	curNode := m.root
+	m.resetMark()
 	var p *trieNode = nil
 
-	ret := make([]int, 0)
+	ret := make([]*Term, 0)
 
-	for _, v := range s {
-		for curNode.child[v] == nil && curNode != this.root {
+	for index, rune := range s {
+		for curNode.child[rune] == nil && curNode != m.root {
 			curNode = curNode.fail
 		}
-		curNode = curNode.child[v]
+		curNode = curNode.child[rune]
 		if curNode == nil {
-			curNode = this.root
+			curNode = m.root
 		}
 
 		p = curNode
-		for p != this.root && p.count > 0 && !this.mark[p.index] {
-			this.mark[p.index] = true
+		for p != m.root && p.count > 0 && !m.mark[p.index] {
+			m.mark[p.index] = true
 			for i := 0; i < p.count; i++ {
-				ret = append(ret, p.index)
+				ret = append(ret, &Term{Index: p.index, EndPosition: index})
 			}
 			p = p.fail
 		}
@@ -85,26 +90,26 @@ func (this *Matcher) Match(s string) []int {
 }
 
 // just return the number of len(Match(s))
-func (this *Matcher) GetMatchResultSize(s string) int {
+func (m *Matcher) GetMatchResultSize(s string) int {
 
-	curNode := this.root
-	this.resetMark()
+	curNode := m.root
+	m.resetMark()
 	var p *trieNode = nil
 
 	num := 0
 
 	for _, v := range s {
-		for curNode.child[v] == nil && curNode != this.root {
+		for curNode.child[v] == nil && curNode != m.root {
 			curNode = curNode.fail
 		}
 		curNode = curNode.child[v]
 		if curNode == nil {
-			curNode = this.root
+			curNode = m.root
 		}
 
 		p = curNode
-		for p != this.root && p.count > 0 && !this.mark[p.index] {
-			this.mark[p.index] = true
+		for p != m.root && p.count > 0 && !m.mark[p.index] {
+			m.mark[p.index] = true
 			num += p.count
 			p = p.fail
 		}
@@ -113,16 +118,16 @@ func (this *Matcher) GetMatchResultSize(s string) int {
 	return num
 }
 
-func (this *Matcher) build() {
+func (m *Matcher) build() {
 	ll := list.New()
-	ll.PushBack(this.root)
+	ll.PushBack(m.root)
 	for ll.Len() > 0 {
 		temp := ll.Remove(ll.Front()).(*trieNode)
 		var p *trieNode = nil
 
 		for i, v := range temp.child {
-			if temp == this.root {
-				v.fail = this.root
+			if temp == m.root {
+				v.fail = m.root
 			} else {
 				p = temp.fail
 				for p != nil {
@@ -133,7 +138,7 @@ func (this *Matcher) build() {
 					p = p.fail
 				}
 				if p == nil {
-					v.fail = this.root
+					v.fail = m.root
 				}
 			}
 			ll.PushBack(v)
@@ -141,8 +146,8 @@ func (this *Matcher) build() {
 	}
 }
 
-func (this *Matcher) insert(s string) {
-	curNode := this.root
+func (m *Matcher) insert(s string) {
+	curNode := m.root
 	for _, v := range s {
 		if curNode.child[v] == nil {
 			curNode.child[v] = newTrieNode()
@@ -150,12 +155,12 @@ func (this *Matcher) insert(s string) {
 		curNode = curNode.child[v]
 	}
 	curNode.count++
-	curNode.index = this.size
-	this.size++
+	curNode.index = m.size
+	m.size++
 }
 
-func (this *Matcher) resetMark() {
-	for i := 0; i < this.size; i++ {
-		this.mark[i] = false
+func (m *Matcher) resetMark() {
+	for i := 0; i < m.size; i++ {
+		m.mark[i] = false
 	}
 }

--- a/ahocorasick_test.go
+++ b/ahocorasick_test.go
@@ -11,18 +11,38 @@ func Test1(t *testing.T) {
 	dictionary := []string{"she", "he", "say", "shr", "her"}
 	ac.Build(dictionary)
 
+	expected := []*Term{
+		{Index: 0, EndPosition: 4},
+		{Index: 1, EndPosition: 4},
+		{Index: 4, EndPosition: 5},
+	}
+
 	ret := ac.Match("yasherhs")
-	if len(ret) != 3 || ret[0] != 0 || ret[1] != 1 || ret[2] != 4 {
-		t.Fatal()
+
+	if len(expected) != len(ret) {
+		t.Errorf("len %d != %d", len(expected), len(ret))
+	}
+
+	for i := range expected {
+		if *expected[i] != *ret[i] {
+			t.Errorf("ret[%d] %v !+ %v", i, *expected[i], *ret[i])
+		}
 	}
 
 	ret = ac.Match("yasherhs")
-	if len(ret) != 3 || ret[0] != 0 || ret[1] != 1 || ret[2] != 4 {
-		t.Fatal()
+
+	if len(expected) != len(ret) {
+		t.Errorf("len %d != %d", len(expected), len(ret))
 	}
 
-	if ac.GetMatchResultSize("yasherhs") != 3 {
-		t.Fatal()
+	for i := range expected {
+		if *expected[i] != *ret[i] {
+			t.Errorf("ret[%d] %v !+ %v", i, *expected[i], *ret[i])
+		}
+	}
+
+	if size := ac.GetMatchResultSize("yasherhs"); len(expected) != size {
+		t.Errorf("size %d != %d", len(expected), size)
 	}
 }
 
@@ -78,7 +98,7 @@ func Test3(t *testing.T) {
 	}
 
 	ret = ac.Match("agbdfgiadafgha")
-	if len(ret) != 1 || dictionary[ret[0]] != "fgh" {
+	if len(ret) != 1 || dictionary[ret[0].Index] != "fgh" {
 		t.Fatal()
 	}
 }
@@ -93,9 +113,7 @@ func Benchmark1(b *testing.B) {
 	ac.Build(dictionary)
 
 	for i := 0; i < b.N; i++ {
-		ret := ac.Match(randWord(5000, 10000))
-		if len(ret) > 0 {
-		}
+		ac.Match(randWord(5000, 10000))
 	}
 }
 
@@ -109,8 +127,7 @@ func Benchmark2(b *testing.B) {
 	ac.Build(dictionary)
 
 	for i := 0; i < b.N; i++ {
-		if ac.GetMatchResultSize(randWord(5000, 10000)) > 0 {
-		}
+		ac.GetMatchResultSize(randWord(5000, 10000))
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gansidui/ahocorasick
+
+go 1.13


### PR DESCRIPTION
This change return the end position of each match along with the index (the current return).

It also make the code for `Match` and `GetMatchResultSize` reentrant by moving the `mark` state out of the Matcher structure. 